### PR TITLE
chore: simplify personas to be an inline trait of a grunt, rather than a reference to a map

### DIFF
--- a/examples/simpleish/seatrial.ron
+++ b/examples/simpleish/seatrial.ron
@@ -4,51 +4,46 @@
     grunts: [
         (
             base_name: "Postmaster General",
-            persona: "poster_child",
             count: 1,
+            persona: (
+                timeout: Seconds(30),
+                sequence: [
+                    LuaFunction("generate_profile"),
+                    Http(Post(
+                        url: "/profile",
+                        body: LuaTableValue("profile"),
+                        headers: { "Content-Type": Value("application/json") },
+                    )),
+                    Combinator(AllOf([
+                        WarnUnlessStatusCodeInRange(200, 299),
+                        WarnUnlessHeaderExists("X-Never-Gonna-Give-You-Up"),
+                    ]))
+                ]
+            ),
         ),
         (
             base_name: "Reloader Grunt",
-            persona: "spam_reloader",
             count: 10,
+            persona: (
+                timeout: Seconds(30),
+
+                sequence: [
+                    LuaFunction("generate_30_day_range"),
+                    Http(Get(
+                        url: "/calendar",
+                        params: {
+                            "start_date": LuaTableValue("start_date"),
+                            "end_date": LuaTableValue("end_date"),
+                        },
+                    )),
+                    Combinator(AllOf([
+                        WarnUnlessStatusCodeInRange(200, 299),
+                        WarnUnlessHeaderExists("X-Never-Gonna-Give-You-Up"),
+                        LuaFunction("is_valid_esoteric_format"),
+                    ])),
+                    ControlFlow(GoTo(index: 0, max_times: 2)),
+                ],
+            ),
         ),
     ],
-
-    personas: {
-        "poster_child": (
-            timeout: Seconds(30),
-            sequence: [
-                LuaFunction("generate_profile"),
-                Http(Post(
-                    url: "/profile",
-                    body: LuaTableValue("profile"),
-                    headers: { "Content-Type": Value("application/json") },
-                )),
-                Combinator(AllOf([
-                    WarnUnlessStatusCodeInRange(200, 299),
-                    WarnUnlessHeaderExists("X-Never-Gonna-Give-You-Up"),
-                ]))
-            ]
-        ),
-        "spam_reloader": (
-            timeout: Seconds(30),
-
-            sequence: [
-                LuaFunction("generate_30_day_range"),
-                Http(Get(
-                    url: "/calendar",
-                    params: {
-                        "start_date": LuaTableValue("start_date"),
-                        "end_date": LuaTableValue("end_date"),
-                    },
-                )),
-                Combinator(AllOf([
-                    WarnUnlessStatusCodeInRange(200, 299),
-                    WarnUnlessHeaderExists("X-Never-Gonna-Give-You-Up"),
-                    LuaFunction("is_valid_esoteric_format"),
-                ])),
-                ControlFlow(GoTo(index: 0, max_times: 2)),
-            ],
-        ),
-    },
 )

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1,6 +1,6 @@
 use nanoserde::DeRon;
 
-use crate::persona::Persona;
+use crate::grunt::Grunt;
 use crate::pipeline::action::PipelineAction;
 use crate::pipeline::step_handler::{
     StepCompletion, StepError, StepHandler, StepHandlerInit, StepResult,
@@ -22,7 +22,7 @@ pub enum Action {
 pub struct CombinatorHandler;
 
 impl StepHandler for CombinatorHandler {
-    fn new(_: &str, _: &Persona) -> StepHandlerInit<Self> {
+    fn new(_: &Grunt) -> StepHandlerInit<Self> {
         Ok(Self {})
     }
 

--- a/src/grunt.rs
+++ b/src/grunt.rs
@@ -2,17 +2,49 @@ use nanoserde::DeRon;
 
 use std::fmt::Display;
 
+#[cfg(test)]
+use crate::config_duration::ConfigDuration;
+use crate::persona::{Persona, PersonaSpec};
+use crate::situation::{SituationParseErr, SituationParseErrKind};
+
 // build out of a GruntSpec during Situation construction
 #[derive(Clone, Debug)]
 pub struct Grunt {
     pub name: String,
-    pub persona_idx: usize,
+    pub persona: Persona,
+}
+
+impl Grunt {
+    pub fn from_spec_with_multiplier(
+        spec: &GruntSpec,
+        multiplier: usize,
+    ) -> Result<Vec<Self>, SituationParseErr> {
+        let num_grunts = spec.real_count() * multiplier;
+        if num_grunts < 1 {
+            return Err(SituationParseErr {
+                kind: SituationParseErrKind::Semantics {
+                    message: "if provided, grunt count must be >=1".into(),
+                    location: "unknown".into(), // this gets replaced upstream
+                },
+            });
+        }
+
+        let mut grunts: Vec<Self> = Vec::with_capacity(num_grunts);
+        for slot in 0..num_grunts {
+            grunts.push(Grunt {
+                name: spec.formatted_name(slot),
+                persona: (&spec.persona).into(),
+            });
+        }
+
+        Ok(grunts)
+    }
 }
 
 #[derive(Clone, Debug, DeRon)]
 pub struct GruntSpec {
     pub base_name: Option<String>,
-    pub persona: String,
+    pub persona: PersonaSpec,
     pub count: Option<usize>,
 }
 
@@ -20,9 +52,10 @@ impl GruntSpec {
     pub fn formatted_name(&self, uniqueness: impl Display) -> String {
         format!(
             "{} {}",
-            self.base_name
-                .clone()
-                .unwrap_or_else(|| format!("Grunt<{}>", self.persona)),
+            self.base_name.clone().unwrap_or_else(|| format!(
+                "Grunt<taking {} actions>",
+                self.persona.sequence.len()
+            )),
             uniqueness,
         )
     }
@@ -36,7 +69,11 @@ impl GruntSpec {
 fn test_formatted_name() {
     let spec = GruntSpec {
         base_name: Some("Jimbo Gruntseph".into()),
-        persona: "blahblah".into(),
+        persona: PersonaSpec {
+            headers: None,
+            sequence: vec![],
+            timeout: ConfigDuration::Seconds(30),
+        },
         count: None,
     };
 
@@ -47,18 +84,26 @@ fn test_formatted_name() {
 fn test_formatted_name_no_base() {
     let spec = GruntSpec {
         base_name: None,
-        persona: "blahblah".into(),
+        persona: PersonaSpec {
+            headers: None,
+            sequence: vec![],
+            timeout: ConfigDuration::Seconds(30),
+        },
         count: None,
     };
 
-    assert_eq!("Grunt<blahblah> 1", spec.formatted_name(1));
+    assert_eq!("Grunt<taking 0 actions> 1", spec.formatted_name(1));
 }
 
 #[test]
 fn test_real_count() {
     let spec = GruntSpec {
         base_name: None,
-        persona: "blahblah".into(),
+        persona: PersonaSpec {
+            headers: None,
+            sequence: vec![],
+            timeout: ConfigDuration::Seconds(30),
+        },
         count: None,
     };
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,7 +4,7 @@ use ureq::{Agent, AgentBuilder};
 use std::collections::HashMap;
 
 use crate::config_duration::ConfigDuration;
-use crate::persona::Persona;
+use crate::grunt::Grunt;
 use crate::pipeline::action::{ConfigActionMap, PipelineAction, Reference};
 use crate::pipeline::step_handler::{
     StepCompletion, StepError, StepHandler, StepHandlerInit, StepResult,
@@ -114,14 +114,11 @@ pub struct HttpHandler {
 }
 
 impl StepHandler for HttpHandler {
-    fn new(grunt_name: &str, persona: &Persona) -> StepHandlerInit<Self> {
+    fn new(grunt: &Grunt) -> StepHandlerInit<Self> {
         Ok(Self {
             agent: AgentBuilder::new()
-                .user_agent(&format!(
-                    "seatrial/grunt={}/persona={}",
-                    grunt_name, persona.name
-                ))
-                .timeout((&persona.spec.timeout).into())
+                .user_agent(&format!("seatrial/grunt={}", grunt.name,))
+                .timeout((&grunt.persona.timeout).into())
                 .build(),
         })
     }

--- a/src/persona.rs
+++ b/src/persona.rs
@@ -5,12 +5,24 @@ use std::collections::HashMap;
 use crate::config_duration::ConfigDuration;
 use crate::pipeline::action::{ConfigActionMap, PipelineAction};
 
-// built out of a PersonaSpec during Situation construction
 #[derive(Clone, Debug)]
 pub struct Persona {
-    pub name: String,
-    pub spec: PersonaSpec,
+    pub timeout: ConfigDuration,
     pub headers: HashMap<String, String>,
+    pub sequence: Vec<PipelineAction>,
+}
+
+impl From<&PersonaSpec> for Persona {
+    fn from(spec: &PersonaSpec) -> Self {
+        Self {
+            timeout: spec.timeout.clone(),
+            sequence: spec.sequence.clone(),
+
+            // TODO: populate with Value/LuaFunction returns, error on other PipelineAction
+            // variants
+            headers: HashMap::new(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, DeRon)]

--- a/src/pipeline/step_handler.rs
+++ b/src/pipeline/step_handler.rs
@@ -2,7 +2,7 @@ use rlua::Error as LuaError;
 
 use std::io::Error as IOError;
 
-use crate::persona::Persona;
+use crate::grunt::Grunt;
 use crate::pipe_contents::PipeContents;
 use crate::pipeline::action::PipelineAction;
 use crate::pipeline::Pipeline;
@@ -61,6 +61,6 @@ pub trait StepHandler
 where
     Self: Sized,
 {
-    fn new(grunt_name: &str, persona: &Persona) -> StepHandlerInit<Self>;
+    fn new(grunt: &Grunt) -> StepHandlerInit<Self>;
     fn step(&self, pl: &Pipeline, pa: &PipelineAction) -> StepResult;
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -2,8 +2,8 @@ use nanoserde::DeRon;
 
 use std::collections::HashMap;
 
+use crate::grunt::Grunt;
 use crate::lua::stdlib::ValidationResult;
-use crate::persona::Persona;
 use crate::pipe_contents::PipeContents;
 use crate::pipeline::action::PipelineAction as PA;
 use crate::pipeline::step_handler::{
@@ -33,7 +33,7 @@ pub enum Action {
 pub struct ValidatorHandler;
 
 impl StepHandler for ValidatorHandler {
-    fn new(_: &str, _: &Persona) -> StepHandlerInit<Self> {
+    fn new(_: &Grunt) -> StepHandlerInit<Self> {
         Ok(Self {})
     }
 


### PR DESCRIPTION
This was always a 1:1 anyway, let's get rid of the silly indirection in the config format